### PR TITLE
fix: try to fix example component lazy import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Workers Deployment
 
 on:
   pull_request:
-    branches: ['main']
+    branches: ['main','next']
   push: 
     branches: ['next']
 

--- a/packages/react/src/env.d.ts
+++ b/packages/react/src/env.d.ts
@@ -1,1 +1,5 @@
-/// <reference types="vite/client" />
+// / <reference types="vite/client" />
+
+interface ImportMeta {
+  glob: <M>(glob: string) => Record<string, () => Promise<M>>
+}

--- a/packages/react/src/examples/index.ts
+++ b/packages/react/src/examples/index.ts
@@ -1,8 +1,8 @@
-const examples = import.meta.glob("./*.js")
+const examples = import.meta.glob("./*.tsx")
 
 export default Object.fromEntries(
   Object.entries(examples).map(([path, module]) => {
-    const name = path.match(/\.\/(.*)\.js$/)?.[1]
+    const name = path.match(/\.\/(.*)\.tsx$/)?.[1]
     return [name, module]
   })
 )

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -1,6 +1,9 @@
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { glob } from "tinyglobby"
 import { defineConfig } from "tsdown"
+
+const importGlobRE = /\bimport\.meta\.glob(?:<\w+>)?\s*\(['|"](.*)['|"]\)/g
 
 export default defineConfig({
   entry: ["src/**/*.{ts,tsx}", "!src/**/stories/**"],
@@ -14,4 +17,29 @@ export default defineConfig({
   loader: {
     ".jpg": "asset",
   },
+  plugins: [
+    {
+      name: "import-glob",
+      transform: {
+        order: "pre",
+        filter: { code: importGlobRE },
+        async handler(code, id) {
+          const [match, globPattern] = Array.from(importGlobRE.exec(code) || [])
+
+          const files = await glob(globPattern, {
+            cwd: path.dirname(id),
+            absolute: true,
+          })
+
+          let imports = ""
+          for (const file of files) {
+            const relative = path.relative(id, file).replace(/^\.\.\//, "./")
+            imports += `"${relative}": () => import("${relative}"),\n`
+          }
+
+          return code.replace(match, `{${imports}}`)
+        },
+      },
+    },
+  ],
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for glob-based dynamic imports, enabling lazy loading of matched modules without manual listings.
  - Example gallery now auto-discovers .tsx examples, improving compatibility with TypeScript-based demos.
  - No breaking changes to the public API.

- Chores
  - Deployment workflow now runs for pull requests targeting main or next, with push-based deployments unchanged for next.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->