### PR TITLE
refactor: migrate shadcn install from spec URLs to namespace system

### DIFF
--- a/apps/www/content/installation/react/next.mdx
+++ b/apps/www/content/installation/react/next.mdx
@@ -21,7 +21,7 @@ Choose between a Next.js project or a Monorepo.
 You can now start adding components to your project.
 
 ```bash
-npx shadcn@latest add https://ui.shipbase.xyz/r/react/button.json
+npx shadcn@latest add @shipbase/button
 ```
 
 The command above will add the `Button` component to your project. You can then import it like this:

--- a/apps/www/src/components/content/code-wrapper/component-add-bash-command.astro
+++ b/apps/www/src/components/content/code-wrapper/component-add-bash-command.astro
@@ -7,9 +7,7 @@ interface Props {
 
 const { name } = Astro.props
 
-// TODO replace this with env or global config
-const HOST = "https://ui.shipbase.xyz"
-const src = `npx shadcn@latest add ${HOST}/r/react/${name}.json`
+const src = `npx shadcn@latest add @shipbase/${name}`
 ---
 
 <BashCommand src={src} lang="bash" className="mt-0" />


### PR DESCRIPTION
## Summary
- Refactored shadcn install commands from spec URLs to clean namespace format
- Updated component install command generator to use `@shipbase/component` syntax
- Replaced hardcoded URL example in Next.js installation documentation

## Changes
- **Before**: `shadcn@latest add https://ui.shipbase.xyz/r/react/collapsible.json`
- **After**: `shadcn@latest add @shipbase/collapsible`

## Files Modified
- `apps/www/src/components/content/code-wrapper/component-add-bash-command.astro` - Updated install command generator
- `apps/www/content/installation/react/next.mdx` - Updated hardcoded example

## Test plan
- [x] Type check passes
- [x] Build registry command works
- [x] Install commands now use namespace format throughout documentation
- [x] Registry system already configured to support @shipbase namespace

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Updated Next.js installation guide to use the new shadcn add syntax with @shipbase packages, providing clearer, shorter commands.

- Refactor
  - Simplified how installation commands are generated and displayed, switching from long JSON URLs to concise package specs for a cleaner copy-paste experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->