### PR TITLE
fix(www): improve mobile responsiveness of tech stack logos in CTA

### DIFF
--- a/apps/www/src/components/landing/cta.astro
+++ b/apps/www/src/components/landing/cta.astro
@@ -59,7 +59,7 @@ import Vue from "@/assets/logos/vue.svg"
     >
       Build with
     </p>
-    <div class="flex justify-center gap-6">
+    <div class="flex flex-wrap justify-center gap-3 sm:gap-6">
       <div class="flex items-center gap-2">
         <TailwindCSS width="24" height="24" />
         <span class="text-sm">Tailwind CSS</span>
@@ -85,7 +85,7 @@ import Vue from "@/assets/logos/vue.svg"
     >
       Supported JavaScript Frameworks
     </p>
-    <div class="flex justify-center gap-16">
+    <div class="flex flex-wrap justify-center gap-6 sm:gap-12 md:gap-16">
       <div class="flex flex-col items-center gap-2">
         <React width="32" height="32" />
         <span class="text-sm">React</span>


### PR DESCRIPTION
## Summary
- Improved mobile responsiveness of tech stack logos in the CTA landing section
- Added `flex-wrap` and responsive gaps to prevent overflow on small screens
- Progressive gap sizing: smaller on mobile, larger on desktop

## Changes
- **"Build with" section**: Added `flex-wrap` and changed gap from `gap-6` to `gap-3 sm:gap-6`
- **"Framework support" section**: Added `flex-wrap` and changed gap from `gap-16` to `gap-6 sm:gap-12 md:gap-16`

## Test plan
- [ ] Test on mobile devices (viewport width < 640px)
- [ ] Verify logos wrap properly without horizontal overflow
- [ ] Confirm spacing looks good across all breakpoints
- [ ] Check that desktop layout remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout on the landing page by enabling wrapping for key sections.
  * Adjusted spacing across breakpoints for smoother alignment on small and medium screens.
  * Refined the “Build with” and “Supported JavaScript Frameworks” sections for better readability and visual balance.
  * No content changes; purely UI/spacing enhancements for a cleaner, more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->